### PR TITLE
Compilation speedup of traversal

### DIFF
--- a/src/traversal_encoding.jl
+++ b/src/traversal_encoding.jl
@@ -62,7 +62,7 @@ function _pred_traversal(::InnerNode, n, p, s="")
     d = printchildren(n)
     l = length(d)
     z = Vector{Vector{String}}[pred_traversal(_ith_child(d, i), p, s * encode(i, l)) for i in 1:l]
-    res = reduce(vcat, z)
+    res = vcat(z...)
     p(n) ? vcat(stringify(s), res) : res
 end 
 

--- a/src/traversal_encoding.jl
+++ b/src/traversal_encoding.jl
@@ -61,7 +61,8 @@ _pred_traversal(::LeafNode, n, p, s="") = p(n) ? [stringify(s)] : String[]
 function _pred_traversal(::InnerNode, n, p, s="")
     d = printchildren(n)
     l = length(d)
-    res = vcat([pred_traversal(_ith_child(d, i), p, s * encode(i, l)) for i in 1:l]...)
+    z = Vector{Vector{String}}[pred_traversal(_ith_child(d, i), p, s * encode(i, l)) for i in 1:l]
+    res = reduce(vcat, z)
     p(n) ? vcat(stringify(s), res) : res
 end 
 

--- a/src/traversal_encoding.jl
+++ b/src/traversal_encoding.jl
@@ -61,10 +61,10 @@ _pred_traversal(::LeafNode, n, p, s="") = p(n) ? [stringify(s)] : String[]
 function _pred_traversal(::InnerNode, n, p, s="")
     d = printchildren(n)
     l = length(d)
-    z = Vector{Vector{String}}[pred_traversal(_ith_child(d, i), p, s * encode(i, l)) for i in 1:l]
-    res = vcat(z...)
+    z = Vector{String}[pred_traversal(_ith_child(d, i), p, s * encode(i, l)) for i in 1:l]
+    res = isempty(z) ? String[] : reduce(vcat, z)
     p(n) ? vcat(stringify(s), res) : res
-end 
+end
 
 list_traversal(n) = pred_traversal(n, t -> true)
 find_traversal(n, x) = pred_traversal(n, t -> x === t)


### PR DESCRIPTION
Speeds up the compilation time for traversal. For some reason, on julia 1.6+ the current version causes severe compile time degradation. 
See the discussion here: https://github.com/JuliaLang/julia/issues/40302
This implements speedup from https://github.com/JuliaLang/julia/issues/40302#issuecomment-812525555

The speedup of tests on julia 1.6.6 looks as follows, when running tests as `@time include(test_f)`:
master branch:
```
Precompiling project...
  2 dependencies successfully precompiled in 4 seconds (2 already precompiled)
     Testing Running tests...
 89.403067 seconds (148.39 M allocations: 8.614 GiB, 2.76% gc time, 99.25% compilation time)
Test Summary: | Pass  Total
iterators.jl  |  684    684
 10.710926 seconds (24.56 M allocations: 1.428 GiB, 3.91% gc time, 97.73% compilation time)
Test Summary: | Pass  Total
maps.jl       |  136    136
  7.877087 seconds (25.56 M allocations: 1.435 GiB, 8.57% gc time, 97.82% compilation time)
Test Summary: | Pass  Total
printing.jl   |  465    465
 10.302835 seconds (16.51 M allocations: 988.514 MiB, 3.34% gc time, 99.49% compilation time)
Test Summary: | Pass  Total
statistics.jl |  239    239
307.203733 seconds (396.45 M allocations: 22.589 GiB, 1.90% gc time, 99.98% compilation time)
Test Summary:         | Pass  Total
traversal_encoding.jl |  110    110
152.992322 seconds (214.67 M allocations: 12.158 GiB, 3.35% gc time, 11.51% compilation time)
Test Summary: | Pass  Total
utilities.jl  |  759    759
     Testing HierarchicalUtils tests passed
```

this PR:
```
Precompiling project...
  2 dependencies successfully precompiled in 4 seconds (2 already precompiled)
     Testing Running tests...
104.856114 seconds (148.39 M allocations: 8.614 GiB, 2.59% gc time, 99.32% compilation time)
Test Summary: | Pass  Total
iterators.jl  |  684    684
 12.898177 seconds (24.56 M allocations: 1.428 GiB, 3.67% gc time, 97.82% compilation time)
Test Summary: | Pass  Total
maps.jl       |  136    136
  9.898649 seconds (25.62 M allocations: 1.436 GiB, 6.20% gc time, 97.40% compilation time)
Test Summary: | Pass  Total
printing.jl   |  465    465
 11.606660 seconds (16.51 M allocations: 988.492 MiB, 3.30% gc time, 99.51% compilation time)
Test Summary: | Pass  Total
statistics.jl |  239    239
  7.279279 seconds (14.83 M allocations: 948.480 MiB, 4.23% gc time, 99.67% compilation time)
Test Summary:         | Pass  Total
traversal_encoding.jl |  110    110
196.642413 seconds (214.75 M allocations: 12.163 GiB, 3.20% gc time, 10.16% compilation time)
Test Summary: | Pass  Total
utilities.jl  |  759    759
     Testing HierarchicalUtils tests passed
```

so in total, tests take ~342.8 s compared to original 578.3 s, which means saving ~4 minutes on my workstation.
The most of time is spent in compilation, so this should speedup usage of all packages using it significantly.

On julia 1.5.4 it looks like this:
```
 99.646756 seconds (146.12 M allocations: 7.502 GiB, 1.95% gc time)
Test Summary: | Pass  Total
iterators.jl  |  684    684
 13.214586 seconds (22.56 M allocations: 1.176 GiB, 2.43% gc time)
Test Summary: | Pass  Total
maps.jl       |  136    136
  9.046619 seconds (21.59 M allocations: 1.088 GiB, 4.03% gc time)
Test Summary: | Pass  Total
printing.jl   |  465    465
 12.860069 seconds (18.40 M allocations: 987.087 MiB, 3.84% gc time)
Test Summary: | Pass  Total
statistics.jl |  239    239
  8.040452 seconds (18.50 M allocations: 1.005 GiB, 3.40% gc time)
Test Summary:         | Pass  Total
traversal_encoding.jl |  110    110
170.229398 seconds (207.04 M allocations: 10.535 GiB, 2.59% gc time)
Test Summary: | Pass  Total
utilities.jl  |  759    759
    Testing HierarchicalUtils tests passed
```
which is 312s in total. So there is still performance degradation on julia 1.6, but not that big.